### PR TITLE
Use `nightly` feature to support stable Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,7 @@ homepage = "https://github.com/Kl4rry/thin-string"
 [dependencies]
 thin-vec = "0.2.12"
 serde = { version = "1.0", optional = true }
+
+[features]
+default = []
+nightly = []


### PR DESCRIPTION
Thanks for making this crate, it's turning out to be super handy in my project!

This change fixes a few methods that broke in recent updates, and adds a new `nightly` feature. Unstable methods are now included only if the `nightly` feature is enabled. This allows the crate to support stable Rust!

This would be a breaking change for code that relies on nightly features being enabled by default, and would require a major version bump. (Alternatively, you could set nightly as enabled by default using `default = ["nightly"]` in Cargo.toml).